### PR TITLE
Added working NFC tag scanning for checking in and out.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "badminton-afhangbord",
-  "version": "0.0.1",
-  "author": "Fedde van Gils <feddevangils@gmail.com>",
+  "version": "0.0.2",
+  "author": "Fedde van Gils <feddevangils@gmail.com>, Simon Mingaars <simon@mingaars.nl>",
   "description": "afhangsysteem badminton",
   "license": null,
   "main": "./dist/electron/main.js",
@@ -55,8 +55,10 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
+    "@pokusew/pcsclite": "^0.6.0",
     "axios": "^0.18.0",
     "dialogs": "^2.0.1",
+    
     "electron-db": "^0.15.2",
     "file-dialog": "^0.0.8",
     "nfc-pcsc": "^0.8.0",
@@ -84,7 +86,6 @@
     "css-loader": "^0.28.11",
     "del": "^3.0.0",
     "devtron": "^1.4.0",
-    "electron": "^2.0.4",
     "electron-builder": "^22.3.2",
     "electron-debug": "^1.5.0",
     "electron-devtools-installer": "^2.2.4",


### PR DESCRIPTION
When scanning, enter does not have to be pushed, modal popup is automatically generated.
When someone is in the pause queue, the system does not see the participant as new.
Changed default behaviour for scanning second time to checking out.
Pausing is now only available by clicking or dragging. Paused queue is not the default queue for not playing.
Application is not started automatically (you need to press the start button).
When someone checks out and in again he will start at the end of the queue
Buttons are back. Most interactivity will be with the tags, only start is needed once. Buttons might be dissabled in the future.